### PR TITLE
Switch from break to continue

### DIFF
--- a/irve/irve.ipynb
+++ b/irve/irve.ipynb
@@ -234,7 +234,7 @@
     "                if pivot not in table_cols:\n",
     "                    missing_pivot.append(pivot)\n",
     "            if missing_pivot:\n",
-    "                break\n",
+    "                continue\n",
     "            for row in table.rows:\n",
     "                borne = {}\n",
     "                for col in columns_mapping:\n",


### PR DESCRIPTION
Related code block in the notebook

```py
for child in [x for x in data_path.iterdir() if x.is_dir()]:
    csvs = list(child.glob('*.csv'))
    for csv in csvs:
        table = parse_csv(csv)
        if table:
            table_cols = [x.lower() for x in table.column_names]
            missing_pivot = []
            for pivot in ['id_station', 'id_pdc', 'date_maj']:
                if pivot not in table_cols:
                    missing_pivot.append(pivot)
            if missing_pivot:
                break # THIS LINE
            for row in table.rows:
               # stuff
```

The current code skips to the next directory when a pivot is missing. It shouldn't move to the next folder, just to the next CSV file. Hence, this PR.