### PR TITLE
Update irve.ipynb

### DIFF
--- a/irve/irve.ipynb
+++ b/irve/irve.ipynb
@@ -228,7 +228,7 @@
     "        # print('ℹ️ doing %s' % csv)\n",
     "        table = parse_csv(csv)\n",
     "        if table:\n",
-    "            table_cols = [x.lower() for x in table.column_names]\n",
+    "            table_cols = [x.lower().strip() for x in table.column_names]\n",
     "            missing_pivot = []\n",
     "            for pivot in ['id_station', 'id_pdc', 'date_maj']:\n",
     "                if pivot not in table_cols:\n",


### PR DESCRIPTION
remove unwanted spaces

In some data, there is a trailing space on "date_maj" (https://www.data.gouv.fr/fr/datasets/r/30155455-de66-4bd2-a242-3217fd6e7489)
What is preferable? Asking for a correction on the source, or just add a strip() like in this PR?